### PR TITLE
File source for stubbed exchanges

### DIFF
--- a/core/src/main/scala/com/dz/stubby/core/service/StubService.scala
+++ b/core/src/main/scala/com/dz/stubby/core/service/StubService.scala
@@ -78,12 +78,15 @@ class StubService extends Logging {
   }
 
   def deleteResponse(exchange:StubExchange) = this.synchronized {
-    val toDelete = responses.filterNot(
-      _.matches(exchange.request).matches
-    )
-    toDelete.foreach { it =>
+    val toDelete = responses.filter{ it =>
+      println("it"+it+"exchange.req"+exchange.request+" match: "+it.matches(exchange.request).matches)
+      it.matches(exchange.request).matches
+    }
+    toDelete.foreach { it:StubServiceExchange =>
       val index = responses.indexOf(it)
+      println("index:"+index)
       responses.remove(index)
+      println("responses="+responses)
     }
   }
 

--- a/core/src/test/scala/com/dz/stubby/core/service/StubServiceTest.scala
+++ b/core/src/test/scala/com/dz/stubby/core/service/StubServiceTest.scala
@@ -186,4 +186,17 @@ class StubServiceTest extends FunSuite {
     assert(result.head.path.get === "/test2")
   }
 
+
+  test("remove exchange by match") {
+    val service = defaultService
+    service.deleteResponse(StubExchange(
+            StubRequest(path = "/foo", method = "GE."),
+            StubResponse(status = CREATED)))
+
+    val result = service.findMatch(defaultRequest)
+
+    assert(result.matchFound)
+    assert(result.response.get.status === OK) // created no longer exists
+    assert(result.attempts.size === 1) // ensure attempts returned
+  }
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -64,7 +64,7 @@ object Dependencies {
 
   lazy val runtime = Seq(
     "org.apache.commons" % "commons-lang3" % "3.1",
-    "org.apache.commons" % "commons-io" % "1.3.2",
+    "commons-io" % "commons-io" % "2.4",
     "org.apache.httpcomponents" % "httpclient" % "4.2.5" withSources(),
     "com.typesafe" %% "scalalogging-log4j" % "1.0.1" withSources(),
     "org.apache.logging.log4j" % "log4j-core" % "2.0-beta3" withSources()

--- a/standalone/src/main/scala/com/dz/stubby/standalone/FileSource.scala
+++ b/standalone/src/main/scala/com/dz/stubby/standalone/FileSource.scala
@@ -3,29 +3,65 @@ package com.dz.stubby.standalone
 import com.dz.stubby.core.service.{JsonServiceInterface, StubService}
 import java.io.File
 import org.apache.commons.io.FileUtils
+
 import com.dz.stubby.core.util.JsonUtils
 import com.dz.stubby.core.model.StubExchange
 import collection.JavaConversions._
 import java.util
+import org.apache.commons.io.monitor.{FileAlterationListenerAdaptor, FileAlterationObserver, FileAlterationMonitor}
 
 
 class FileSource(paths:Seq[File], service: StubService, jsonService: JsonServiceInterface) {
+  val monitor = new FileAlterationMonitor(10L)
 
-  def loadInitialFiles() {
-    val jsonFiles:Seq[File] = paths.flatMap(FileUtils.listFiles(_, Array("json"), true).asInstanceOf[util.LinkedList[File]])
-    jsonFiles.foreach((f:File) => loadFile(f))
+  def watchFolders() = {
+    paths.foreach(path => monitor.addObserver(watchFolder(path)))
+    monitor.start()
+    this
   }
 
-  def loadFile(file:File) {
+  def watchFolder(path:File) = {
+    val monitor = new FileAlterationObserver(path)
+    monitor.addListener(new FileAlterationListenerAdaptor(){
+      override def onFileCreate(file:File) {
+        loadFile(file)
+      }
+
+      override def onFileChange(file:File) {
+        reloadFile(file)
+      }
+
+      override def onFileDelete(file:File) {
+        deleteFile(file)
+      }
+    })
+    monitor
+  }
+
+  def loadInitialFiles() = {
+    val jsonFiles:Seq[File] = paths.flatMap(FileUtils.listFiles(_, Array("json"), true).asInstanceOf[util.LinkedList[File]])
+    jsonFiles.foreach((f:File) => loadFile(f))
+    this
+  }
+
+  def safeAction(file:File, action:(StubExchange) => Unit) {
     try {
       println("reading:"+file.getName)
       val json = FileUtils.readFileToString(file)
       val exchange:StubExchange = JsonUtils.deserialize[StubExchange](json).nilLists()
       //TODO: this disallows multiple matches, would be nice to allow fall through cases
-      service.deleteResponse(exchange)
-      service.addResponse(exchange)
+      action(exchange)
     } catch {
-      case e:Throwable => System.err.println("failed to load file: "+ name+" error\n\t"+e.getMessage)
+      case e:Throwable => System.err.println("failed to load file: "+ file.getName+" error\n\t"+e.getMessage)
     }
   }
+
+  def loadFile(file:File) = safeAction(file, (exchange)=> service.addResponse(exchange))
+
+  def deleteFile(file:File) = safeAction(file, (exchange) => service.deleteResponse(exchange))
+
+  def reloadFile(file:File) = safeAction(file, (exchange) => {
+    service.deleteResponse(exchange)
+    service.addResponse(exchange)
+  })
 }


### PR DESCRIPTION
Additional arguments after port will be used as source directory trees.

Files with the json extension will be loaded as stub data on app startup
Delete, Create and Modification of json files will be reflected in running stub server
